### PR TITLE
NextAuth authentication fixed

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -64,17 +64,12 @@ async function prismaFetch(username: string, method: string, args: any) {
 /**
  * Sign in with the given username and password
  */
-export async function signIn(creds: Credential) {
-  debugger;
-  return await nextAuthSignIn('credentials', { ...creds, redirect: false }) as unknown as SignInResponse;
-}
+export const signIn = async (creds: Credential) => await nextAuthSignIn('credentials', { ...creds, redirect: false }) as unknown as SignInResponse;
 
 /**
  * Sign out the current user. Wraps around both the NextAuth signOut and Firebase signOut methods
  */
-export async function signOut() {
-  await Promise.all([firebaseSignOut(FIREBASE_AUTH), nextAuthSignOut({ redirect: false })]);
-}
+export const signOut = async() => await Promise.all([firebaseSignOut(FIREBASE_AUTH), nextAuthSignOut({ redirect: false })]);
 
 type SignUpParams = {
   username: string;

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,44 +1,10 @@
 import { signInWithEmailAndPassword } from '@firebase/auth';
 import NextAuth from 'next-auth/next';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { LunchHitchUser } from '../../../auth';
 import { FIREBASE_AUTH } from '../../../firebase';
 import prisma from '../../../prisma';
 
 export default NextAuth({
-  callbacks: {
-    // user received from authorize, token to send to session
-    jwt: ({ token, user }) => {
-      console.log('jwt callback user value', user);
-      return Promise.resolve({ ...token, user });
-    },
-    async session({ session, token }) {
-      // session is current session object
-      // user received from jwt callback
-      const user = token.user as LunchHitchUser;
-
-      console.log('Session callback user value', user);
-
-      const emailResult = await prisma.userInfo.findFirst({
-        where: {
-          id: user.username,
-        },
-      });
-
-      if (!emailResult) {
-        // TODO error handling
-        throw new Error('Prisma did not return an email for this account');
-      }
-
-      return {
-        ...session,
-        user: {
-          ...user,
-          email: emailResult.email,
-        },
-      };
-    },
-  },
   providers: [
     CredentialsProvider({
       name: 'Credentials',
@@ -48,13 +14,23 @@ export default NextAuth({
       },
       async authorize(credentials) {
         if (!credentials) throw new Error('Credentials cannot be null');
-
         const { username, password } = credentials;
+
         const result = await signInWithEmailAndPassword(FIREBASE_AUTH, `${username}@lunchhitch.firebaseapp.com`, password);
+        const emailResult = await prisma.userInfo.findFirst({
+          where: {
+            id: username,
+          },
+        });
+
+      if (!emailResult) {
+        // TODO error handling
+        throw new Error('Prisma did not return an email for this account');
+      }
 
         return {
           displayName: result.user.displayName,
-          // getIdToken: result.user.getIdToken,
+          email: emailResult.email,
           username,
         };
       },

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -54,23 +54,25 @@ export default function LoginPage() {
           border: '5px solid #50C878',
         }}
         >
-          {loginError}
           <Formik
             initialValues={{
               username: '',
               password: '',
             }}
-            validateOnChange={false}
-            validateOnBlur={false}
+            validateOnChange
+            validateOnBlur
+            validateOnMount={false}
             validationSchema={yup.object({
-              username: yup.string().required(),
-              password: yup.string().required(),
+              username: yup.string().required('Username is required!'),
+              password: yup.string().required('Password is required!'),
             })}
             onSubmit={async (values, actions) => {
               try {
                 const result = await signIn(values);
 
                 if (!result.ok) throw result.error;
+
+                // router.push('/profile');
               } catch (error: any) {
                 actions.setFieldValue('password', '');
                 setLoginError(firebaseErrorHandler(error, {
@@ -89,6 +91,7 @@ export default function LoginPage() {
                     flexDirection: 'column',
                   }}
                 >
+                  {loginError || Object.values(errors).at(0)}<br />
                   Username
                   <TextField
                     type="text"


### PR DESCRIPTION
When we authenticate users, we need to retrieve additional information from our databases (like retrieving their email). I moved this to the `authorize` method within the credentials provider, out from the session callback, which could be called any number of times as NextAuth updates sessions.